### PR TITLE
Remove invalid element properties from input

### DIFF
--- a/src/components/formComponents/Button.tsx
+++ b/src/components/formComponents/Button.tsx
@@ -9,8 +9,7 @@ interface Props {
 }
 
 const Button = ({ formProps }: Props) => {
-  const { buttonProps, customStyle } = formProps;
-  const { title } = buttonProps;
+  const { buttonProps, customStyle, title } = formProps;
   return (
     <StyledButton customStyle={customStyle} {...buttonProps}>
       <Text>{title}</Text>

--- a/src/components/formComponents/Checkbox.tsx
+++ b/src/components/formComponents/Checkbox.tsx
@@ -2,19 +2,17 @@ import styled from '@emotion/styled'
 import { darken } from 'polished'
 import React from 'react'
 import { CustomStyle, InputFormProps } from '../../types'
-import HtmlParser from '../HtmlParser'
 
 interface Props {
   formProps: InputFormProps
 }
 
 const Checkbox = ({ formProps }: Props) => {
-  const { inputProps, form, customStyle } = formProps
-  const { label, name } = inputProps
+  const { inputProps, form, customStyle } = formProps;
+  const { name } = inputProps
   const error = form.formState.errors[name];
   return (
     <Label customStyle={customStyle}>
-      {label != null && <HtmlParser html={label} />}
       <input {...inputProps} type='checkbox' />
       <Checkmark error={Boolean(error)} customStyle={customStyle} />
       {error && <Error customStyle={customStyle}>{error.message}</Error>}

--- a/src/components/formComponents/TextInput.tsx
+++ b/src/components/formComponents/TextInput.tsx
@@ -15,7 +15,7 @@ const TextInput = ({ formProps }: Props) => {
   const [isPasswordVisible, setPasswordVisible] = useState(false)
   const { inputProps, form, customStyle } = formProps
   const { type, name } = inputProps
-  const error = form.formState.errors[name];
+  const error = form.formState.errors[name]
   return (
     <Flex flex={1} position='relative'>
       <StyledInput
@@ -65,11 +65,11 @@ const StyledInput = styled.input<{ error: boolean; customStyle: CustomStyle }>`
       error
         ? customStyle.errorColor
         : darken(0.1, customStyle.inputBorderColor as string)};
-
   }
 
   &:focus {
-    border-color: ${({ customStyle }) => darken(0.1, customStyle.inputBorderColor as string)};
+    border-color: ${({ customStyle }) =>
+      darken(0.1, customStyle.inputBorderColor as string)};
   }
 
   border-radius: ${({ customStyle }) => customStyle.borderRadius};
@@ -92,7 +92,8 @@ const ShowPasswordButton = styled.button<{ customStyle: CustomStyle }>`
   svg {
     width: 20px;
     height: 20px;
-    fill: ${({ customStyle }) => darken(0.5, customStyle.inputBorderColor as string)};
+    fill: ${({ customStyle }) =>
+      darken(0.5, customStyle.inputBorderColor as string)};
   }
 `
 

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -1,5 +1,5 @@
 import { ValidationValueMessage } from "react-hook-form";
-import { Validation, Validations } from "./types";
+import { Item, Validation, Validations } from "./types";
 
 export const getTransformedValidation = (
   getValues: (field: string) => string,
@@ -32,3 +32,36 @@ export const getTransformedValidation = (
   }
   return transformedValidation;
 };
+
+const inputPropsWhiteList = ["name", "type", "ref", "onChange", "onBlur", "defaultValue", "disabled", "options", "placeholder"]
+export const getOnlyInputProps = (input: Item) => {
+  const cleanInput = { ...input };
+
+  Object.keys(input).forEach(key => {
+    if(!inputPropsWhiteList.includes(key)){
+      delete cleanInput[key];
+    }
+  });
+
+  return {
+    ...cleanInput,
+    disabled: cleanInput.disabled === "true"
+  };
+}
+
+const buttonPropsWhiteList = ["type", "ref", "onClick", "disabled", "options"];
+export const getOnlyButtontProps = (button: Item) => {
+  const cleanButton = { ...button };
+
+  Object.keys(button).forEach(key => {
+    if(!buttonPropsWhiteList.includes(key)){
+      delete cleanButton[key];
+    }
+  });
+
+  return {
+    ...cleanButton,
+    disabled: cleanButton.disabled === "true"
+  };
+}
+

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -121,6 +121,8 @@ interface FormProps {
 
 export interface ButtonFormProps extends FormProps {
   buttonProps: ButtonProps
+  title?: string;
+  isLoading: boolean;
 }
 
 export interface InputFormProps extends FormProps {


### PR DESCRIPTION
Added whitelist for inputs and buttons to filter invalid element properties from dom. For example it means, that now you can get "title" prop for button component on the same level as form / customProps / buttonProps - 

before:
```
const Button = ({ formProps }: Props) => {
  const { buttonProps, customStyle, form } = formProps;
  const { title } = buttonProps;
  return (
    <button {...buttonProps}>
      <span>{title}</span>
    </button>
  );
};
```

now
```
const Button = ({ formProps }: Props) => {
  const { buttonProps, customStyle, title, form } = formProps;
  return (
    <button  {...buttonProps}>
      <span>{title}</span>
    </button>
  );
};
```

